### PR TITLE
Post Soft Delete 구현

### DIFF
--- a/src/main/java/com/seniors/api/comment/Comment.java
+++ b/src/main/java/com/seniors/api/comment/Comment.java
@@ -1,6 +1,5 @@
 package com.seniors.api.comment;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.seniors.api.common.BaseEntity;
 import com.seniors.api.post.domain.Post;
 import jakarta.persistence.*;
@@ -8,10 +7,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE Comment SET isDeleted = true WHERE id = ?")
+@Where(clause = "isDeleted = false")
 public class Comment extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,21 +26,21 @@ public class Comment extends BaseEntity {
 	@Column(columnDefinition = "text not null COMMENT '댓글 내용'")
 	private String content;
 
-	@Column(columnDefinition = "tinyint(3) not null default 0 COMMENT '삭제 상태'")
-	private Integer isDeleted;
+//	@Column(columnDefinition = "tinyint(3) not null default 0 COMMENT '삭제 상태'")
+//	private Integer isDeleted;
+	private boolean isDeleted = Boolean.FALSE;
 
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "postId")
-	@JsonIgnore
 	private Post post;
 
-	public static Comment initComment(String nickname, String content,  Post post) {
+	public static Comment initComment(String nickname, String content, Post post) {
 		return Comment.builder().nickname(nickname).content(content)
-				.isDeleted(0).post(post).build();
+				.isDeleted(false).post(post).build();
 	}
 
 	@Builder
-	public Comment(String nickname, String content, Integer isDeleted, Post post) {
+	public Comment(String nickname, String content, Boolean isDeleted, Post post) {
 		this.nickname = nickname;
 		this.content = content;
 		this.isDeleted = isDeleted;

--- a/src/main/java/com/seniors/api/post/controller/PostController.java
+++ b/src/main/java/com/seniors/api/post/controller/PostController.java
@@ -28,4 +28,10 @@ public class PostController {
 		Post post = postService.findPost(postId);
 		return DataResponseDto.of(post);
 	}
+
+	@DeleteMapping("/{postId}")
+	public DataResponseDto<String> postRemove(@PathVariable Long postId) {
+		postService.removePost(postId);
+		return DataResponseDto.of("SUCCESS");
+	}
 }

--- a/src/main/java/com/seniors/api/post/domain/Post.java
+++ b/src/main/java/com/seniors/api/post/domain/Post.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import com.seniors.api.common.BaseEntity;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +16,8 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE Post SET isDeleted = true WHERE id = ?")
+@Where(clause = "isDeleted = false")
 public class Post extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,11 +30,9 @@ public class Post extends BaseEntity {
 	@Lob
 	private String content;
 
-	@Column(columnDefinition = "tinyint(3) not null default 1 COMMENT '게시글 노출 여부'")
-	private Integer display;
-
-	@Column(columnDefinition = "tinyint(3) not null default 0 COMMENT '삭제 여부'")
-	private Integer isDeleted;
+//	@Column(columnDefinition = "tinyint(3) not null default 0 COMMENT '삭제 여부'")
+//	private Integer isDeleted;
+	private boolean isDeleted = Boolean.FALSE;
 
 	@Column(columnDefinition = "int unsigned not null default 0 COMMENT '게시글 조회 수'")
 	private Integer viewCount;
@@ -40,15 +42,14 @@ public class Post extends BaseEntity {
 
 	@OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.REMOVE)
 	private List<Comment> comments = new ArrayList<>();
-	public static Post initPost(String title, String content, Integer display) {
-		return Post.builder().title(title).content(content).display(display).isDeleted(0).viewCount(0).likeCount(0).build();
+	public static Post initPost(String title, String content) {
+		return Post.builder().title(title).content(content).isDeleted(false).viewCount(0).likeCount(0).build();
 	}
 
 	@Builder
-	public Post(String title, String content, Integer display, Integer isDeleted, Integer viewCount, Integer likeCount, List<Comment> comments) {
+	public Post(String title, String content, Boolean isDeleted, Integer viewCount, Integer likeCount) {
 		this.title = title;
 		this.content = content;
-		this.display = display;
 		this.isDeleted = isDeleted;
 		this.viewCount = viewCount;
 		this.likeCount = likeCount;

--- a/src/main/java/com/seniors/api/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/seniors/api/post/repository/PostRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.seniors.api.post.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.seniors.api.post.domain.Post;
-import com.seniors.api.post.domain.QPosts;
+import com.seniors.api.post.domain.QPost;
 import com.seniors.common.exception.post.PostNotFound;
 import com.seniors.common.repository.BasicRepoSupport;
 import jakarta.persistence.EntityManager;
@@ -18,17 +18,17 @@ public class PostRepositoryImpl extends BasicRepoSupport implements PostReposito
 	@Override
 	public Post getOnePost(Long postId) {
 		Post post = jpaQueryFactory
-				.selectFrom(QPosts.posts)
-				.leftJoin(QPosts.posts.comments).fetchJoin()
-				.where(QPosts.posts.id.eq(postId))
+				.selectFrom(QPost.post)
+				.leftJoin(QPost.post.comments).fetchJoin()
+				.where(QPost.post.id.eq(postId))
 				.fetchOne();
 
 		if (post == null)
 			throw new PostNotFound();
 		else {
-			jpaQueryFactory.update(QPosts.posts)
-					.set(QPosts.posts.viewCount, QPosts.posts.viewCount.add(1))
-					.where(QPosts.posts.id.eq(postId))
+			jpaQueryFactory.update(QPost.post)
+					.set(QPost.post.viewCount, QPost.post.viewCount.add(1))
+					.where(QPost.post.id.eq(postId))
 					.execute();
 			em.clear();
 		}

--- a/src/main/java/com/seniors/api/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/seniors/api/post/repository/PostRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.seniors.api.post.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.seniors.api.post.domain.Post;
-import com.seniors.api.post.domain.QPost;
+import com.seniors.api.post.domain.QPosts;
 import com.seniors.common.exception.post.PostNotFound;
 import com.seniors.common.repository.BasicRepoSupport;
 import jakarta.persistence.EntityManager;
@@ -18,19 +18,17 @@ public class PostRepositoryImpl extends BasicRepoSupport implements PostReposito
 	@Override
 	public Post getOnePost(Long postId) {
 		Post post = jpaQueryFactory
-				.selectFrom(QPost.post)
-				.leftJoin(QPost.post.comments).fetchJoin()
-				.where(QPost.post.id.eq(postId))
-				.where(QPost.post.isDeleted.eq(0))
-				.where(QPost.post.display.eq(1))
+				.selectFrom(QPosts.posts)
+				.leftJoin(QPosts.posts.comments).fetchJoin()
+				.where(QPosts.posts.id.eq(postId))
 				.fetchOne();
 
 		if (post == null)
 			throw new PostNotFound();
 		else {
-			jpaQueryFactory.update(QPost.post)
-					.set(QPost.post.viewCount, QPost.post.viewCount.add(1))
-					.where(QPost.post.id.eq(postId))
+			jpaQueryFactory.update(QPosts.posts)
+					.set(QPosts.posts.viewCount, QPosts.posts.viewCount.add(1))
+					.where(QPosts.posts.id.eq(postId))
 					.execute();
 			em.clear();
 		}

--- a/src/main/java/com/seniors/api/post/service/PostService.java
+++ b/src/main/java/com/seniors/api/post/service/PostService.java
@@ -18,6 +18,11 @@ public class PostService {
 	}
 
 	@Transactional
+	public void removePost(Long postId) {
+		postRepository.deleteById(postId);
+	}
+
+	@Transactional
 	public Post findPost(Long postId) {
 		return postRepository.getOnePost(postId);
 	}

--- a/src/main/java/com/seniors/api/post/service/PostService.java
+++ b/src/main/java/com/seniors/api/post/service/PostService.java
@@ -14,7 +14,7 @@ public class PostService {
 	private final PostRepository postRepository;
 
 	public void addPost(PostDto.Post postDto) {
-		postRepository.save(Post.initPost(postDto.getTitle(), postDto.getContent(), 1));
+		postRepository.save(Post.initPost(postDto.getTitle(), postDto.getContent()));
 	}
 
 	@Transactional


### PR DESCRIPTION
## 📕 제목
Post Soft Delete 구현

## 📗 작업 내용
기존 isDeleted를 int값으로 사용해 soft delete를 구현하였으나, JPA에서 지원되는 @Where과 @SQLDelete로 soft delete 새로 구현

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1
- [x] 작업내용2
- [x] 작업내용3

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
Post Entity에서 상단에 사용된 어노테이션을 확인하시고, Entity에서 isDelete의 설정값을 바꿨습니다.
- 특이사항1
- 특이사항2
