### PR TITLE
DB 이중화(master, slave) 기능 추가 

### DIFF
--- a/src/main/java/com/seniors/common/constant/DataSourceConstants.java
+++ b/src/main/java/com/seniors/common/constant/DataSourceConstants.java
@@ -1,0 +1,8 @@
+package com.seniors.common.constant;
+
+public class DataSourceConstants {
+
+    public static final String MASTER_DATASOURCE = "masterDataSource";
+    public static final String SLAVE_DATASOURCE = "slaveDataSource";
+
+}

--- a/src/main/java/com/seniors/config/DataSourceConfig.java
+++ b/src/main/java/com/seniors/config/DataSourceConfig.java
@@ -1,0 +1,66 @@
+package com.seniors.config;
+
+import com.google.common.collect.ImmutableMap;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+import static com.seniors.common.constant.DataSourceConstants.MASTER_DATASOURCE;
+import static com.seniors.common.constant.DataSourceConstants.SLAVE_DATASOURCE;
+
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean(MASTER_DATASOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.master.hikari")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(SLAVE_DATASOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.slave.hikari")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            // masterDataSource와 slaveDataSource라는 이름을 가진 Bean을 주입
+            @Qualifier(MASTER_DATASOURCE) DataSource masterDataSource,
+            @Qualifier(SLAVE_DATASOURCE) DataSource slaveDataSource) {
+
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        Map<Object, Object> datasourceMap = ImmutableMap.<Object, Object>builder()
+                .put("master", masterDataSource)
+                .put("slave", slaveDataSource)
+                .build();
+
+        routingDataSource.setTargetDataSources(datasourceMap);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        // 지연 연결 기능을 제공하기 위해서 사용
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+
+}

--- a/src/main/java/com/seniors/config/JpaConfig.java
+++ b/src/main/java/com/seniors/config/JpaConfig.java
@@ -1,0 +1,55 @@
+package com.seniors.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement
+public class JpaConfig {
+
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            @Qualifier("dataSource") DataSource dataSource) {
+
+        LocalContainerEntityManagerFactoryBean entityManagerFactory
+                = new LocalContainerEntityManagerFactoryBean();
+
+        entityManagerFactory.setDataSource(dataSource);
+        entityManagerFactory.setPackagesToScan("com.seniors.domain");
+        entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
+        entityManagerFactory.setPersistenceUnitName("entityManager");
+
+        return entityManagerFactory;
+    }
+
+    private JpaVendorAdapter jpaVendorAdapter() {
+        HibernateJpaVendorAdapter hibernateJpaVendorAdapter = new HibernateJpaVendorAdapter();
+        // 여기서 create, update 등 ddl-auto 값 설정 가능
+        hibernateJpaVendorAdapter.setGenerateDdl(true);
+        hibernateJpaVendorAdapter.setShowSql(true);
+        hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQLDialect");
+        hibernateJpaVendorAdapter.setDatabase(Database.MYSQL);
+
+        return hibernateJpaVendorAdapter;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager (
+
+            @Qualifier("entityManagerFactory") LocalContainerEntityManagerFactoryBean entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
+        return jpaTransactionManager;
+    }
+}

--- a/src/main/java/com/seniors/config/RoutingDataSource.java
+++ b/src/main/java/com/seniors/config/RoutingDataSource.java
@@ -1,0 +1,23 @@
+package com.seniors.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (isReadOnly) {
+            log.info("Slave DataSource 호출 => ");
+        } else {
+            log.info("Master DataSource 호출");
+        }
+        return isReadOnly ? "slave" : "master";
+    }
+}


### PR DESCRIPTION
## 📕 DB 이중화(master, slave) 기능 추가 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] rds를 master, slave로 분기

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- @Transactional이면 master, @Transactional(readonly = true)면 slave
- master : 삽입 , 수정, 삭제 담당
- slave : 조회 담당
- 현재는 ddl-auto : update 상태
- 참고하면 좋은 블로그 : [https://velog.io/@ch4570/MySQL-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%B6%84%EC%82%B0-%EC%B2%98%EB%A6%AC%EB%A5%BC-%EC%9C%84%ED%95%9C-Master-Slave-%EC%9D%B4%EC%A4%91%ED%99%94%EB%A5%BC-%EA%B5%AC%EC%84%B1%ED%95%98%EB%8B%A4Spring%EA%B3%BC-JPA-%EC%84%A4%EC%A0%95]
