### PR TITLE
이력서 등록, 상세 조회, 리스트 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.7.1'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -40,6 +41,8 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
 	implementation 'org.json:json:20220320'
+
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	//log
 	implementation "com.github.maricn:logback-slack-appender:1.4.0"

--- a/src/main/java/com/seniors/config/S3Config.java
+++ b/src/main/java/com/seniors/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.seniors.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/seniors/config/S3Uploader.java
+++ b/src/main/java/com/seniors/config/S3Uploader.java
@@ -1,0 +1,74 @@
+package com.seniors.config;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor    // final 멤버변수가 있으면 생성자 항목에 포함시킴
+@Component
+@Service
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // MultipartFile을 전달받아 File로 전환한 후 S3에 업로드
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + uploadFile.getName();
+        String uploadImageUrl = putS3(uploadFile, fileName);
+
+        removeNewFile(uploadFile);  // 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
+
+        return uploadImageUrl;      // 업로드된 파일의 S3 URL 주소 반환
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName, uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)	// PublicRead 권한으로 업로드 됨
+        );
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if(targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        }else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) throws  IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        if(convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/com/seniors/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/seniors/domain/resume/controller/ResumeController.java
@@ -41,7 +41,8 @@ public class ResumeController {
             @ModelAttribute @Valid ResumeDto.SaveResumeReq resumeDto, BindingResult bindingResult,
             @LoginUsers CustomUserDetails userDetails
         ) throws IOException {
-        return DataResponseDto.of(resumeService.addResume(resumeDto, bindingResult, userDetails.getUserId()));
+        resumeService.addResume(resumeDto, bindingResult, userDetails.getUserId());
+        return DataResponseDto.of(null);
     }
 
     @Operation(summary = "이력서 조회")

--- a/src/main/java/com/seniors/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/seniors/domain/resume/controller/ResumeController.java
@@ -1,0 +1,72 @@
+package com.seniors.domain.resume.controller;
+
+import com.seniors.common.annotation.LoginUsers;
+import com.seniors.common.dto.DataResponseDto;
+import com.seniors.config.security.CustomUserDetails;
+import com.seniors.domain.post.dto.PostDto;
+import com.seniors.domain.resume.dto.ResumeDto;
+import com.seniors.domain.resume.service.ResumeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+
+@Tag(name = "이력서", description = "이력서 API 명세서")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/resumes")
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    @Operation(summary = "이력서 등록")
+    @ApiResponse(responseCode = "200", description = "등록 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+    @PostMapping("")
+    public DataResponseDto<List<String>> resumeAdd(
+            @ModelAttribute @Valid ResumeDto.SaveResumeReq resumeDto, BindingResult bindingResult,
+            @LoginUsers CustomUserDetails userDetails
+        ) throws IOException {
+        return DataResponseDto.of(resumeService.addResume(resumeDto, bindingResult, userDetails.getUserId()));
+    }
+
+    @Operation(summary = "이력서 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+    @GetMapping("/{resumeId}")
+    public DataResponseDto<ResumeDto.GetResumeRes> resumeDetails(
+            @PathVariable Long resumeId,
+            @LoginUsers CustomUserDetails userDetails
+    ) {
+        ResumeDto.GetResumeRes getResumeRes = resumeService.findResume(resumeId, userDetails.getUserId());
+        return DataResponseDto.of(getResumeRes);
+    }
+
+
+    @Operation(summary = "이력서 리스트 조회")
+    @ApiResponse(responseCode = "200", description = "리스트 조회 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+    @GetMapping("")
+    public DataResponseDto<Slice<ResumeDto.GetResumeByQueryDslRes>> resumeList(
+            @RequestParam int size,
+            @RequestParam Long lastId,
+            @LoginUsers CustomUserDetails userDetails
+    ) {
+        Pageable pageable = PageRequest.of(0, size);
+        return resumeService.findResumeList(pageable, lastId, userDetails.getUserId());
+    }
+}

--- a/src/main/java/com/seniors/domain/resume/dto/CareerDto.java
+++ b/src/main/java/com/seniors/domain/resume/dto/CareerDto.java
@@ -1,0 +1,105 @@
+package com.seniors.domain.resume.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import com.seniors.domain.resume.entity.Career;
+import com.seniors.domain.resume.entity.Resume;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.Year;
+
+import static java.lang.Boolean.FALSE;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+@Setter
+public class CareerDto {
+
+    @Data
+    @Setter
+    public static class saveCareerReq extends Career {
+
+
+        @NotNull(message = "입사연도는 비워둘 수 없습니다.")
+        private int startedAt;
+
+        @NotNull(message = "퇴사연도는 비워둘 수 없습니다.")
+        private int endedAt;
+
+        @NotEmpty(message = "회사명은 비워둘 수 없습니다.")
+        @Size(max = 30, message = "회사명은 30자 이하여야 합니다.")
+        private String company;
+
+        @NotEmpty(message = "직함은 비워둘 수 없습니다.")
+        @Size(max = 30, message = "직함은 30자 이하여야 합니다.")
+        private String title;
+
+        private Boolean isAttendanced;
+
+        @NotEmpty(message = "내용은 비워둘 수 없습니다.")
+        private String content;
+
+
+    }
+
+    @Data
+    public static class getCareerRes {
+        private Long id;
+        private int startedAt;
+        private int endedAt;
+        private String company;
+
+        private String title;
+        private Boolean isAttendanced;
+
+        private String content;
+
+        @Builder
+        private getCareerRes(Career career){
+            this.id = career.getId();
+            this.startedAt = career.getStartedAt();
+            this.endedAt = career.getEndedAt();
+            this.company = career.getCompany();
+            this.title = career.getCompany();
+            this.isAttendanced = career.getIsAttendanced();
+            this.content = career.getContent();
+        }
+
+        public static getCareerRes from(Career career) {
+            return getCareerRes.builder()
+                    .career(career)
+                    .build();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class getCareerQueryDslRes{
+        private Long id;
+        private int startedAt;
+        private int endedAt;
+        private String company;
+
+        private String title;
+        private Boolean isAttendanced;
+
+        private String content;
+
+        public getCareerQueryDslRes(Career career){
+            this.id = career.getId();
+            this.startedAt = career.getStartedAt();
+            this.endedAt = career.getEndedAt();
+            this.company = career.getCompany();
+            this.title = career.getTitle();
+            this.isAttendanced = career.getIsAttendanced();
+            this.content = career.getContent();
+        }
+    }
+}

--- a/src/main/java/com/seniors/domain/resume/dto/CertificateDto.java
+++ b/src/main/java/com/seniors/domain/resume/dto/CertificateDto.java
@@ -1,0 +1,101 @@
+package com.seniors.domain.resume.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import com.seniors.domain.resume.entity.Certificate;
+import com.seniors.domain.resume.entity.Resume;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import static java.lang.Boolean.FALSE;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+@Setter
+public class CertificateDto {
+
+    @Data
+    @Setter
+    public static class saveCertificateReq extends Certificate {
+
+        @NotEmpty(message = "자격증 명은 비워둘 수 없습니다.")
+        @Size(max = 30, message = "자격증 명은 30자 이하여야 합니다.")
+        private String name;
+
+        private String rating;
+
+        @NotNull(message = "발행 연도는 비워둘 수 없습니다.")
+        private int issuedYear;
+
+        @NotNull(message = "발행 월은 비워둘 수 없습니다.")
+        private int issuedMonth;
+
+        private Boolean isIssued;
+
+    }
+
+    @Data
+    public static class getCertificateRes {
+
+        private Long id;
+
+        private String name;
+
+        private String rating;
+
+        private int issuedYear;
+
+        private int issuedMonth;
+
+        private Boolean isIssued;
+
+        @Builder
+        private getCertificateRes(Certificate certificate) {
+            this.id = certificate.getId();
+            this.name = certificate.getName();
+            this.rating = certificate.getRating();
+            this.issuedYear = certificate.getIssuedYear();
+            this.issuedMonth = certificate.getIssuedMonth();
+            this.isIssued = certificate.getIsIssued();
+        }
+
+        public static getCertificateRes from(Certificate certificate) {
+            return getCertificateRes.builder()
+                    .certificate(certificate)
+                    .build();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class getCertificateQueryDslRes {
+
+        private Long id;
+
+        private String name;
+
+        private String rating;
+
+        private int issuedYear;
+
+        private int issuedMonth;
+
+        private Boolean isIssued;
+
+        public getCertificateQueryDslRes(Certificate certificate) {
+            this.id = certificate.getId();
+            this.name = certificate.getName();
+            this.rating = certificate.getRating();
+            this.issuedYear = certificate.getIssuedYear();
+            this.issuedMonth = certificate.getIssuedMonth();
+            this.isIssued = certificate.getIsIssued();
+        }
+
+    }
+}

--- a/src/main/java/com/seniors/domain/resume/dto/EducationDto.java
+++ b/src/main/java/com/seniors/domain/resume/dto/EducationDto.java
@@ -1,0 +1,110 @@
+package com.seniors.domain.resume.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import com.seniors.domain.resume.entity.Certificate;
+import com.seniors.domain.resume.entity.Education;
+import com.seniors.domain.resume.entity.Resume;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.Year;
+
+import static java.lang.Boolean.FALSE;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+@Setter
+public class EducationDto {
+
+    @Data
+    @Setter
+    public static class saveEducationReq extends Education{
+
+        @NotEmpty(message = "학교/교육기관 명은 비워둘 수 없습니다.")
+        @Size(max = 30, message = "학교/교육기관 명은 30자 이하여야 합니다.")
+        private String institution;
+
+        private String process;
+
+        @NotNull(message = "시작 연도는 비워둘 수 없습니다.")
+        private int startedAt;
+
+        @NotNull(message = "종료 연도는 비워둘 수 없습니다.")
+        private int endedAt;
+
+        private String content;
+
+        private Boolean isProcessed;
+
+    }
+
+    @Data
+    public static class getEducationRes {
+
+        private Long id;
+
+        private String institution;
+
+        private String process;
+
+        private int startedAt;
+
+        private int endedAt;
+
+        private String content;
+        private Boolean isProcessed;
+
+        @Builder
+        private getEducationRes(Education education){
+            this.id = education.getId();
+            this.institution = education.getInstitution();
+            this.process = education.getProcess();
+            this.startedAt = education.getStartedAt();
+            this.endedAt = education.getEndedAt();
+            this.content = education.getContent();
+            this.isProcessed = education.getIsProcessed();
+        }
+
+        public static EducationDto.getEducationRes from(Education education) {
+            return getEducationRes.builder()
+                    .education(education)
+                    .build();
+        }
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class getEducationByQueryDslRes {
+        private Long id;
+
+        private String institution;
+
+        private String process;
+
+        private int startedAt;
+
+        private int endedAt;
+
+        private String content;
+        private Boolean isProcessed;
+
+        public getEducationByQueryDslRes(Education education) {
+            this.id = education.getId();
+            this.institution = education.getInstitution();
+            this.process = education.getProcess();
+            this.startedAt = education.getStartedAt();
+            this.endedAt = education.getEndedAt();
+            this.content = education.getContent();
+            this.isProcessed = education.getIsProcessed();
+        }
+    }
+
+}

--- a/src/main/java/com/seniors/domain/resume/dto/ResumeDto.java
+++ b/src/main/java/com/seniors/domain/resume/dto/ResumeDto.java
@@ -1,0 +1,148 @@
+package com.seniors.domain.resume.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import com.seniors.domain.comment.entity.Comment;
+import com.seniors.domain.post.entity.Post;
+import com.seniors.domain.resume.entity.Career;
+import com.seniors.domain.resume.entity.Certificate;
+import com.seniors.domain.resume.entity.Education;
+import com.seniors.domain.resume.entity.Resume;
+import com.seniors.domain.users.dto.UsersDto.GetPostUserRes;
+import com.seniors.domain.users.entity.Users;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.seniors.domain.comment.dto.CommentDto.GetCommentRes;
+import static java.lang.Boolean.FALSE;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+@Setter
+public class ResumeDto {
+	@Data
+	@Setter
+	public static class SaveResumeReq {
+
+		private String introduce;
+
+		@NotEmpty(message = "직종은 비워둘 수 없습니다.")
+		@Size(max = 30, message = "직종은 30자 이하여야 합니다.")
+		private String occupation;
+
+		private Boolean isOpened;
+
+		@NotEmpty(message = "이름은 비워둘 수 없습니다.")
+		@Size(max = 30, message = "이름은 30자 이하여야 합니다.")
+		private String name;
+
+		private MultipartFile image;
+
+		@Valid
+		private List<CertificateDto.saveCertificateReq> certificateList = new ArrayList<>();
+
+		@Valid
+		private List<CareerDto.saveCareerReq> careerList = new ArrayList<>();
+
+		@Valid
+		private List<EducationDto.saveEducationReq> educationList = new ArrayList<>();
+
+	}
+
+	@Data
+	public static class GetResumeRes {
+
+		private Long id;
+
+		private String introduce;
+
+		private String photoUrl;
+
+		private String occupation;
+
+		private Boolean isOpened;
+
+		private String name;
+
+		private List<CertificateDto.getCertificateRes> certificates;
+
+		private List<CareerDto.getCareerRes> careers;
+
+		private List<EducationDto.getEducationRes> educations;
+
+
+		@Builder
+		private GetResumeRes(Resume resume) {
+			this.id = resume.getId();
+			this.introduce = resume.getIntroduce();
+			this.photoUrl = resume.getPhotoUrl();
+			this.occupation = resume.getOccupation();
+			this.isOpened = resume.getIsOpened();
+			this.name = resume.getName();
+			this.certificates = resume.getCertificates().stream().map(CertificateDto.getCertificateRes::from)
+					.collect(Collectors.toList());
+			this.careers = resume.getCareers().stream().map(CareerDto.getCareerRes::from)
+					.collect(Collectors.toList());
+			this.educations = resume.getEducations().stream().map(EducationDto.getEducationRes::from)
+					.collect(Collectors.toList());
+		}
+
+		public static GetResumeRes from(Resume resume) {
+			return GetResumeRes.builder()
+					.resume(resume)
+					.build();
+		}
+	}
+
+	@Data
+	@NoArgsConstructor
+	@Getter
+	@Setter
+	public static class GetResumeByQueryDslRes {
+
+		private Long id;
+		private String introduce;
+
+		private String photoUrl;
+
+		private String occupation;
+
+		private Boolean isOpened;
+
+		private String name;
+
+		private List<CertificateDto.getCertificateQueryDslRes> certificates;
+
+		private List<CareerDto.getCareerQueryDslRes> careers;
+
+		private List<EducationDto.getEducationByQueryDslRes> educations;
+
+
+		public GetResumeByQueryDslRes(Resume resume) {
+			this.id = resume.getId();
+			this.introduce = resume.getIntroduce();
+			this.photoUrl = resume.getPhotoUrl();
+			this.occupation = resume.getOccupation();
+			this.isOpened = resume.getIsOpened();
+			this.name = resume.getName();
+			this.certificates = resume.getCertificates().stream().map(CertificateDto.getCertificateQueryDslRes::new).collect(Collectors.toList());
+			this.careers = resume.getCareers().stream().map(CareerDto.getCareerQueryDslRes::new).collect(Collectors.toList());
+			this.educations = resume.getEducations().stream().map(EducationDto.getEducationByQueryDslRes::new).collect(Collectors.toList());
+		}
+
+	}
+}

--- a/src/main/java/com/seniors/domain/resume/entity/Career.java
+++ b/src/main/java/com/seniors/domain/resume/entity/Career.java
@@ -1,0 +1,74 @@
+package com.seniors.domain.resume.entity;
+
+import com.seniors.domain.common.BaseEntity;
+import com.seniors.domain.common.BaseTimeEntity;
+import com.seniors.domain.resume.dto.CareerDto;
+import com.seniors.domain.resume.dto.ResumeDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.Year;
+
+import static java.lang.Boolean.FALSE;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "isDeleted = false")
+@SQLDelete(sql = "UPDATE career SET isDeleted = true WHERE id = ?")
+public class Career extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "int not null COMMENT '입사 연도'")
+    private int startedAt;
+
+    @Column(columnDefinition = "int not null COMMENT '퇴사 연도'")
+    private int endedAt;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '회사'")
+    private String company;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '직함'")
+    private String title;
+
+    @Column
+    private Boolean isAttendanced;
+
+    @Column(columnDefinition = "text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '내용'")
+    private String content;
+
+    @Column
+    private Boolean isDeleted = FALSE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resumeId")
+    private Resume resume;
+
+    @Builder
+    public Career(int startedAt, int endedAt, String company, String title, Boolean isAttendanced, String content, Resume resume) {
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.company = company;
+        this.title = title;
+        this.isAttendanced = isAttendanced;
+        this.content = content;
+        this.resume = resume;
+    }
+
+    public static Career from(CareerDto.saveCareerReq saveCareerReq){
+        return Career.builder()
+                .startedAt(saveCareerReq.getStartedAt())
+                .endedAt(saveCareerReq.getEndedAt())
+                .company(saveCareerReq.getCompany())
+                .title(saveCareerReq.getTitle())
+                .isAttendanced(saveCareerReq.getIsAttendanced())
+                .content(saveCareerReq.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/seniors/domain/resume/entity/Certificate.java
+++ b/src/main/java/com/seniors/domain/resume/entity/Certificate.java
@@ -1,0 +1,70 @@
+package com.seniors.domain.resume.entity;
+
+import com.seniors.domain.common.BaseEntity;
+import com.seniors.domain.common.BaseTimeEntity;
+import com.seniors.domain.resume.dto.CertificateDto;
+import com.seniors.domain.resume.dto.ResumeDto;
+import com.seniors.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import static java.lang.Boolean.FALSE;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "isDeleted = false")
+@SQLDelete(sql = "UPDATE certificate SET isDeleted = true WHERE id = ?")
+public class Certificate extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '이름'")
+    private String name;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '점수/등급'")
+    private String rating;
+
+    @Column(columnDefinition = "int not null COMMENT '발행 연도'")
+    private int issuedYear;
+
+    @Column(columnDefinition = "int not null COMMENT '발행 월'")
+    private int issuedMonth;
+
+    @Column
+    private Boolean isIssued;
+
+    @Column
+    private Boolean isDeleted = FALSE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resumeId")
+    private Resume resume;
+
+    @Builder
+    public Certificate(String name, String rating, int issuedYear, int issuedMonth, Boolean isIssued) {
+        this.name = name;
+        this.rating = rating;
+        this.issuedYear = issuedYear;
+        this.issuedMonth = issuedMonth;
+        this.isIssued = isIssued;
+        this.resume = resume;
+    }
+
+    public static Certificate from(CertificateDto.saveCertificateReq saveCertificateReq){
+        return Certificate.builder()
+                .name(saveCertificateReq.getName())
+                .rating(saveCertificateReq.getRating())
+                .issuedYear(saveCertificateReq.getIssuedYear())
+                .issuedMonth(saveCertificateReq.getIssuedMonth())
+                .isIssued(saveCertificateReq.getIsIssued())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/seniors/domain/resume/entity/Certificate.java
+++ b/src/main/java/com/seniors/domain/resume/entity/Certificate.java
@@ -47,7 +47,7 @@ public class Certificate extends BaseTimeEntity {
     private Resume resume;
 
     @Builder
-    public Certificate(String name, String rating, int issuedYear, int issuedMonth, Boolean isIssued) {
+    public Certificate(String name, String rating, int issuedYear, int issuedMonth, Boolean isIssued, Resume resume) {
         this.name = name;
         this.rating = rating;
         this.issuedYear = issuedYear;

--- a/src/main/java/com/seniors/domain/resume/entity/Education.java
+++ b/src/main/java/com/seniors/domain/resume/entity/Education.java
@@ -1,0 +1,75 @@
+package com.seniors.domain.resume.entity;
+
+import com.seniors.domain.common.BaseEntity;
+import com.seniors.domain.common.BaseTimeEntity;
+import com.seniors.domain.resume.dto.CertificateDto;
+import com.seniors.domain.resume.dto.EducationDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.Year;
+
+import static java.lang.Boolean.FALSE;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "isDeleted = false")
+@SQLDelete(sql = "UPDATE education SET isDeleted = true WHERE id = ?")
+public class Education extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '기관'")
+    private String institution;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '전공/과정'")
+    private String process;
+
+    @Column(columnDefinition = "int not null COMMENT '시작 연도'")
+    private int startedAt;
+
+    @Column(columnDefinition = "int not null COMMENT '종료 연도'")
+    private int endedAt;
+
+    @Column(columnDefinition = "text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '내용'")
+    private String content;
+
+    @Column
+    private Boolean isProcessed;
+
+    @Column
+    private Boolean isDeleted = FALSE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resumeId")
+    private Resume resume;
+
+    @Builder
+    public Education(String institution, String process, int startedAt, int endedAt, String content, Boolean isProcessed, Resume resume) {
+        this.institution = institution;
+        this.process = process;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.content = content;
+        this.isProcessed = isProcessed;
+        this.resume = resume;
+    }
+
+    public static Education from(EducationDto.saveEducationReq saveEducationReq){
+        return Education.builder()
+                .institution(saveEducationReq.getInstitution())
+                .process(saveEducationReq.getProcess())
+                .startedAt(saveEducationReq.getStartedAt())
+                .endedAt(saveEducationReq.getEndedAt())
+                .content(saveEducationReq.getContent())
+                .isProcessed(saveEducationReq.getIsProcessed())
+                .build();
+    }
+
+}

--- a/src/main/java/com/seniors/domain/resume/entity/Resume.java
+++ b/src/main/java/com/seniors/domain/resume/entity/Resume.java
@@ -1,0 +1,107 @@
+package com.seniors.domain.resume.entity;
+
+import com.seniors.domain.comment.entity.Comment;
+import com.seniors.domain.common.BaseEntity;
+import com.seniors.domain.common.BaseTimeEntity;
+import com.seniors.domain.post.entity.Post;
+import com.seniors.domain.resume.dto.ResumeDto;
+import com.seniors.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.hibernate.type.TrueFalseConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Boolean.FALSE;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "isDeleted = false")
+@SQLDelete(sql = "UPDATE resume SET isDeleted = true WHERE id = ?")
+public class Resume extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci  null COMMENT '소개글'")
+    private String introduce;
+
+    @Column(columnDefinition = "text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '사진 URL'")
+    private String photoUrl;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '직종'")
+    private String occupation;
+
+    @Column
+    private Boolean isDeleted = FALSE;
+
+    @Column
+    private Boolean isOpened;
+
+    @Column(columnDefinition = "varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci not null COMMENT '이름'")
+    private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private Users users;
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "resume", orphanRemoval = true, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Certificate> certificates = new ArrayList<>();
+
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "resume", orphanRemoval = true, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Career> careers = new ArrayList<>();
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "resume", orphanRemoval = true, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Education> educations = new ArrayList<>();
+
+    @Builder
+    public Resume(String introduce, String photo_url, String occupation, Boolean isOpened, String name, Users users) {
+        this.introduce = introduce;
+        this.photoUrl = photo_url;
+        this.occupation = occupation;
+        this.isOpened = isOpened;
+        this.name = name;
+        this.users = users;
+    }
+
+    public static Resume of(ResumeDto.SaveResumeReq resumeReq, Users users) {
+        return Resume.builder()
+                .introduce(resumeReq.getIntroduce())
+                .occupation(resumeReq.getOccupation())
+                .isOpened(resumeReq.getIsOpened())
+                .name(resumeReq.getName())
+                .users(users)
+                .build();
+    }
+
+    public void addCareer(Career career) {
+        this.getCareers().add(career);
+        career.setResume(this);
+    }
+
+    public void addCertificate(Certificate certificate) {
+        this.getCertificates().add(certificate);
+        certificate.setResume(this);
+    }
+
+    public void addEducation(Education education) {
+        this.getEducations().add(education);
+        education.setResume(this);
+    }
+
+    public void uploadPhotoUrl(String photoUrl){
+        this.photoUrl = photoUrl;
+    }
+}

--- a/src/main/java/com/seniors/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/seniors/domain/resume/repository/ResumeRepository.java
@@ -6,9 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 
+@Repository
 public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeRepositoryCustom {
+
+    Optional<Resume> findByUsersId(Long userId);
 
 }

--- a/src/main/java/com/seniors/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/seniors/domain/resume/repository/ResumeRepository.java
@@ -1,0 +1,14 @@
+package com.seniors.domain.resume.repository;
+
+import com.seniors.domain.resume.entity.Resume;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeRepositoryCustom {
+
+}

--- a/src/main/java/com/seniors/domain/resume/repository/ResumeRepositoryCustom.java
+++ b/src/main/java/com/seniors/domain/resume/repository/ResumeRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.seniors.domain.resume.repository;
+
+import com.seniors.domain.resume.dto.ResumeDto;
+import com.seniors.domain.resume.entity.Resume;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ResumeRepositoryCustom {
+
+    Slice<ResumeDto.GetResumeByQueryDslRes> findResumeList(Pageable pageable, Long lastId, Long userId);
+}

--- a/src/main/java/com/seniors/domain/resume/repository/ResumeRepositoryImpl.java
+++ b/src/main/java/com/seniors/domain/resume/repository/ResumeRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.seniors.domain.resume.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seniors.domain.resume.dto.*;
+import com.seniors.domain.resume.entity.QCertificate;
+import com.seniors.domain.resume.entity.QResume;
+import com.seniors.domain.resume.entity.Resume;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.querydsl.core.group.GroupBy.list;
+import static com.seniors.domain.resume.entity.QCareer.career;
+import static com.seniors.domain.resume.entity.QCertificate.certificate;
+import static com.seniors.domain.resume.entity.QEducation.education;
+import static com.seniors.domain.resume.entity.QResume.resume;
+import static org.hibernate.query.results.Builders.fetch;
+
+@RequiredArgsConstructor
+@Repository
+public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<ResumeDto.GetResumeByQueryDslRes> findResumeList(Pageable pageable, Long lastId, Long userId) {
+
+        List<Resume> results = queryFactory
+                .selectFrom(resume)
+                .where(
+                        userIdEq(userId),
+                        ltResumeId(lastId),
+                        resume.isOpened.eq(Boolean.TRUE)
+                )
+                .orderBy(resume.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        List<ResumeDto.GetResumeByQueryDslRes> resultDtos = results.stream()
+                .map(ResumeDto.GetResumeByQueryDslRes::new)
+                .collect(Collectors.toList());
+
+        return checkLastPage(pageable, resultDtos);
+    }
+    // no-offset 방식 처리하는 메서드
+    private BooleanExpression ltResumeId(Long lastId) {
+        if (lastId == null) {
+            return null;
+        }
+        return resume.id.lt(lastId);
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        return resume.users.id.ne(userId);
+    }
+
+    // 무한 스크롤 방식 처리하는 메서드
+    private Slice<ResumeDto.GetResumeByQueryDslRes> checkLastPage(Pageable pageable, List<ResumeDto.GetResumeByQueryDslRes> resultDtos) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (resultDtos.size() > pageable.getPageSize()) {
+            hasNext = true;
+            resultDtos.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(resultDtos, pageable, hasNext);
+    }
+
+
+}

--- a/src/main/java/com/seniors/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/seniors/domain/resume/service/ResumeService.java
@@ -1,6 +1,7 @@
 package com.seniors.domain.resume.service;
 
 import com.seniors.common.dto.DataResponseDto;
+import com.seniors.common.exception.type.BadRequestException;
 import com.seniors.common.exception.type.NotFoundException;
 import com.seniors.config.S3Uploader;
 import com.seniors.domain.resume.dto.CareerDto;
@@ -50,7 +51,7 @@ public class ResumeService {
                 String message = fieldError.getDefaultMessage();
                 errorMessages.add(message);
             }
-            return errorMessages;
+            throw new BadRequestException(String.join(", ", errorMessages));
         }
         Users user =  usersRepository.findById(userId).orElseThrow(
                 () -> new NotFoundException()

--- a/src/main/java/com/seniors/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/seniors/domain/resume/service/ResumeService.java
@@ -1,0 +1,103 @@
+package com.seniors.domain.resume.service;
+
+import com.seniors.common.dto.DataResponseDto;
+import com.seniors.common.exception.type.NotFoundException;
+import com.seniors.config.S3Uploader;
+import com.seniors.domain.resume.dto.CareerDto;
+import com.seniors.domain.resume.dto.CertificateDto;
+import com.seniors.domain.resume.dto.EducationDto;
+import com.seniors.domain.resume.dto.ResumeDto;
+import com.seniors.domain.resume.entity.Career;
+import com.seniors.domain.resume.entity.Certificate;
+import com.seniors.domain.resume.entity.Education;
+import com.seniors.domain.resume.entity.Resume;
+import com.seniors.domain.resume.repository.ResumeRepository;
+import com.seniors.domain.users.entity.Users;
+import com.seniors.domain.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.seniors.domain.resume.dto.ResumeDto.SaveResumeReq;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+
+    private final ResumeRepository resumeRepository;
+    private final UsersRepository usersRepository;
+
+    private final S3Uploader s3Uploader;
+    @Transactional
+    public List<String> addResume(SaveResumeReq resumeReq, BindingResult bindingResult, Long userId) throws IOException {
+        if(bindingResult.hasErrors()) {
+            List<ObjectError> errors = bindingResult.getAllErrors();
+            List<String> errorMessages = new ArrayList<>();
+
+            for (ObjectError error : errors) {
+                FieldError fieldError = (FieldError) error;
+                String message = fieldError.getDefaultMessage();
+                errorMessages.add(message);
+            }
+            return errorMessages;
+        }
+        Users user =  usersRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException()
+        );
+        String photoUrl = "https://seniors-for-bucket.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8%EC%9D%B4%EB%AF%B8%EC%A7%80.jpg";
+
+        if(resumeReq.getImage() != null) {
+            photoUrl = s3Uploader.upload(resumeReq.getImage(), "images");
+        }
+        Resume resume = Resume.of(resumeReq, user);
+        resume.uploadPhotoUrl(photoUrl);
+        for(CareerDto.saveCareerReq saveCareerReq  : resumeReq.getCareerList()){
+            Career career = Career.from(saveCareerReq);
+            resume.addCareer(career);
+        }
+        for(CertificateDto.saveCertificateReq saveCertificateReq : resumeReq.getCertificateList()){
+            Certificate certificate = Certificate.from(saveCertificateReq);
+            resume.addCertificate(certificate);
+        }
+        for(EducationDto.saveEducationReq saveEducationReq : resumeReq.getEducationList()){
+            Education education = Education.from(saveEducationReq);
+            resume.addEducation(education);
+        }
+        resumeRepository.save(resume);
+        return null;
+    }
+
+    @Transactional(readOnly = true)
+    public ResumeDto.GetResumeRes findResume(Long resumeId, Long userId){
+        Users user =  usersRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException()
+        );
+        Resume resume =  resumeRepository.findById(resumeId).orElseThrow(
+                () -> new NotFoundException()
+        );
+
+        return ResumeDto.GetResumeRes.from(resume);
+    }
+
+    @Transactional(readOnly = true)
+    public DataResponseDto<Slice<ResumeDto.GetResumeByQueryDslRes>> findResumeList(Pageable pageable, Long lastId, Long userId){
+        Users user =  usersRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException()
+        );
+        Slice<ResumeDto.GetResumeByQueryDslRes> result = resumeRepository.findResumeList(pageable, lastId, user.getId());
+
+
+        return DataResponseDto.of(result);
+    }
+}

--- a/src/main/java/com/seniors/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/seniors/domain/resume/service/ResumeService.java
@@ -41,7 +41,10 @@ public class ResumeService {
 
     private final S3Uploader s3Uploader;
     @Transactional
-    public List<String> addResume(SaveResumeReq resumeReq, BindingResult bindingResult, Long userId) throws IOException {
+    public Long addResume(SaveResumeReq resumeReq, BindingResult bindingResult, Long userId) throws IOException {
+        if (resumeRepository.findByUsersId(userId).isPresent()) {
+            throw new IllegalStateException("이미 해당 유저의 이력서가 존재합니다.");
+        }
         if(bindingResult.hasErrors()) {
             List<ObjectError> errors = bindingResult.getAllErrors();
             List<String> errorMessages = new ArrayList<>();
@@ -75,8 +78,8 @@ public class ResumeService {
             Education education = Education.from(saveEducationReq);
             resume.addEducation(education);
         }
-        resumeRepository.save(resume);
-        return null;
+        Resume savedResume = resumeRepository.save(resume);
+        return savedResume.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/seniors/domain/resume/service/ResumeServiceTest.java
+++ b/src/test/java/com/seniors/domain/resume/service/ResumeServiceTest.java
@@ -1,0 +1,283 @@
+package com.seniors.domain.resume.service;
+
+import com.seniors.common.constant.OAuthProvider;
+import com.seniors.domain.resume.dto.CareerDto;
+import com.seniors.domain.resume.dto.CertificateDto;
+import com.seniors.domain.resume.dto.EducationDto;
+import com.seniors.domain.resume.dto.ResumeDto;
+import com.seniors.domain.resume.entity.Career;
+import com.seniors.domain.resume.entity.Certificate;
+import com.seniors.domain.resume.entity.Education;
+import com.seniors.domain.resume.entity.Resume;
+import com.seniors.domain.resume.repository.ResumeRepository;
+import com.seniors.domain.users.entity.Users;
+import com.seniors.domain.users.repository.UsersRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("dev")
+class ResumeServiceTest {
+
+    @Autowired
+    private ResumeRepository resumeRepository;
+
+    @Autowired
+    private UsersRepository usersRepository;
+
+    @Test
+    @DisplayName("이력서 등록하기 테스트")
+    void addResume() throws IOException {
+        // given
+        Users users = Users.builder()
+                .snsId("aewvewvewvwe")
+                .email("abc@naver.com")
+                .nickname("apple")
+                .oAuthProvider(null)
+                .gender("male")
+                .birthday("08-18")
+                .ageRange("20~29")
+                .profileImageUrl("https:~")
+                .build();
+        Users savedUser = usersRepository.save(users);
+        Resume resume = Resume.builder()
+                .introduce("안녕하세요 !!!")
+                .photo_url("https:~~")
+                .occupation("개발자")
+                .isOpened(true)
+                .name("박철수")
+                .users(savedUser)
+                .build();
+
+        Certificate certificate = Certificate.builder()
+                .name("OPIC")
+                .rating("AL")
+                .issuedYear(2015)
+                .issuedMonth(8)
+                .isIssued(true)
+                .build();
+        resume.addCertificate(certificate);
+        Career career = Career.builder()
+                .startedAt(1998)
+                .endedAt(2007)
+                .company("Naver")
+                .title("CTO")
+                .isAttendanced(false)
+                .content("정산 업무 담당")
+                .build();
+        resume.addCareer(career);
+        Education education = Education.builder()
+                .institution("ABC 대학교")
+                .process("컴퓨터 공학과")
+                .startedAt(1980)
+                .endedAt(1984)
+                .content("컴퓨터 공학 전공했습니다.")
+                .isProcessed(false)
+                .build();
+        resume.addEducation(education);
+
+        // when
+        Resume savedResume = resumeRepository.save(resume);
+
+        // then
+        assertEquals(savedResume, resume);
+
+    }
+
+    @Test
+    @DisplayName("이력서 상세 조회 테스트")
+    void findResume() {
+        // given
+        Users users = Users.builder()
+                .snsId("aewvewvewvwe")
+                .email("abc@naver.com")
+                .nickname("apple")
+                .oAuthProvider(null)
+                .gender("male")
+                .birthday("08-18")
+                .ageRange("20~29")
+                .profileImageUrl("https:~")
+                .build();
+        Users savedUser = usersRepository.save(users);
+        Resume resume = Resume.builder()
+                .introduce("안녕하세요 !!!")
+                .photo_url("https:~~")
+                .occupation("개발자")
+                .isOpened(true)
+                .name("박철수")
+                .users(savedUser)
+                .build();
+
+        Certificate certificate = Certificate.builder()
+                .name("OPIC")
+                .rating("AL")
+                .issuedYear(2015)
+                .issuedMonth(8)
+                .isIssued(true)
+                .build();
+        resume.addCertificate(certificate);
+        Career career = Career.builder()
+                .startedAt(1998)
+                .endedAt(2007)
+                .company("Naver")
+                .title("CTO")
+                .isAttendanced(false)
+                .content("정산 업무 담당")
+                .build();
+        resume.addCareer(career);
+        Education education = Education.builder()
+                .institution("ABC 대학교")
+                .process("컴퓨터 공학과")
+                .startedAt(1980)
+                .endedAt(1984)
+                .content("컴퓨터 공학 전공했습니다.")
+                .isProcessed(false)
+                .build();
+        resume.addEducation(education);
+        Resume savedResume = resumeRepository.save(resume);
+
+        // when
+        Resume findResume = resumeRepository.findById(savedResume.getId())
+                .orElseThrow(() ->new IllegalArgumentException());
+        Assertions.assertEquals(resumeRepository.count(), 1);
+        Assertions.assertEquals(savedResume, findResume);
+    }
+
+    @Test
+    @DisplayName("이력서 리스트 조회 테스트")
+    void findResumeList() {
+
+        // given
+        // 이력서 1
+        Users user1 = Users.builder()
+                .snsId("aaaaaaaaaaaa")
+                .email("abc@naver.com")
+                .nickname("apple")
+                .oAuthProvider(null)
+                .gender("male")
+                .birthday("08-18")
+                .ageRange("20~29")
+                .profileImageUrl("https:~")
+                .build();
+        Users savedUser1 = usersRepository.save(user1);
+
+        Resume resume1 = Resume.builder()
+                .introduce("안녕하세요 !!!")
+                .photo_url("https:~~")
+                .occupation("개발자")
+                .isOpened(true)
+                .name("박철수")
+                .users(savedUser1)
+                .build();
+
+        Certificate certificate1 = Certificate.builder()
+                .name("OPIC")
+                .rating("AL")
+                .issuedYear(2015)
+                .issuedMonth(8)
+                .isIssued(true)
+                .build();
+        resume1.addCertificate(certificate1);
+
+        Career career = Career.builder()
+                .startedAt(1998)
+                .endedAt(2007)
+                .company("Naver")
+                .title("CTO")
+                .isAttendanced(false)
+                .content("정산 업무 담당")
+                .build();
+        resume1.addCareer(career);
+
+        Education education1 = Education.builder()
+                .institution("ABC 대학교")
+                .process("컴퓨터 공학과")
+                .startedAt(1980)
+                .endedAt(1984)
+                .content("컴퓨터 공학 전공했습니다.")
+                .isProcessed(false)
+                .build();
+        resume1.addEducation(education1);
+
+        Resume savedResume1 = resumeRepository.save(resume1);
+
+        // 이력서 2
+        Users user2 = Users.builder()
+                .snsId("bbbbbbbbbbbb")
+                .email("cba@naver.com")
+                .nickname("banana")
+                .oAuthProvider(null)
+                .gender("female")
+                .birthday("01-28")
+                .ageRange("20~29")
+                .profileImageUrl("https:~")
+                .build();
+        Users savedUser2 = usersRepository.save(user2);
+
+        Resume resume2 = Resume.builder()
+                .introduce("안녕하세요 !!!")
+                .photo_url("https:~~")
+                .occupation("개발자")
+                .isOpened(true)
+                .name("박철수")
+                .users(savedUser2)
+                .build();
+
+        Certificate certificate2 = Certificate.builder()
+                .name("OPIC")
+                .rating("AL")
+                .issuedYear(2015)
+                .issuedMonth(8)
+                .isIssued(true)
+                .build();
+        resume2.addCertificate(certificate2);
+
+        Career career2 = Career.builder()
+                .startedAt(1998)
+                .endedAt(2007)
+                .company("Naver")
+                .title("CTO")
+                .isAttendanced(false)
+                .content("정산 업무 담당")
+                .build();
+        resume2.addCareer(career2);
+
+        Education education2 = Education.builder()
+                .institution("ABC 대학교")
+                .process("컴퓨터 공학과")
+                .startedAt(1980)
+                .endedAt(1984)
+                .content("컴퓨터 공학 전공했습니다.")
+                .isProcessed(false)
+                .build();
+        resume2.addEducation(education2);
+
+        Resume savedResume2 = resumeRepository.save(resume2);
+
+        // when
+        List<Resume> resumeList = resumeRepository.findAll();
+
+        // then
+        assertEquals(2, resumeList.size());
+
+    }
+}


### PR DESCRIPTION
## 📕 이력서 등록, 상세 조회, 리스트 조회 구현

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역
- [x] s3 설정
- [x] 이력서 등록 : 프로필 기본 이미지를 s3에 저장해두었음, 만약 프론트쪽에서 이미지를 지정 안해주면 서버에서 기본 이미지 url을 db에 저장
- [x] 이력서 상세 조회 
- [x] 이력서 리스트 조회 : no-offset 페이지네이션 구현

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 테스트코드 : 테스트코드가 처음이라 제대로 짜기에는 시간이 좀 걸릴거 같습니다. 일단 여기에 S3 설정 코드가 들어있어서 여기까지만 짜고 추후 리팩토링해보려 합니다!!
