### PR TITLE
Swagger Response DTO 수정

### DIFF
--- a/src/main/java/com/seniors/config/SwaggerConfig.java
+++ b/src/main/java/com/seniors/config/SwaggerConfig.java
@@ -1,8 +1,11 @@
 package com.seniors.config;
 
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
@@ -28,11 +31,25 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI getOpenApi() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization Token");
+        SecurityRequirement securityItem = new SecurityRequirement()
+                .addList("bearerAuth");
         return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(securityItem)
                 .info(getApiInfo());
+    }
+    private SecurityScheme getJwtSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER);
+//              .name(TOKEN)
     }
 
     private Info getApiInfo() {
+
         return new Info()
                 .title("Seniors API")
                 .description("Seniors API 명세서")

--- a/src/main/java/com/seniors/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/seniors/domain/auth/controller/AuthController.java
@@ -3,19 +3,22 @@ package com.seniors.domain.auth.controller;
 import com.seniors.domain.auth.dto.AuthTokens;
 import com.seniors.domain.auth.kakao.KakaoLoginParams;
 import com.seniors.domain.auth.service.OAuthLoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
+@Tag(name = "소셜 인증", description = "소셜 API 명세서")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
 	private final OAuthLoginService oAuthLoginService;
 
+	@Operation(summary = "카카오 로그인/회원가입")
 	@PostMapping("/kakao")
 	public ResponseEntity<AuthTokens> loginKakao(@RequestBody KakaoLoginParams params) {
 		return ResponseEntity.ok(oAuthLoginService.login(params));

--- a/src/main/java/com/seniors/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/seniors/domain/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.seniors.domain.comment.controller;
 
 import com.seniors.common.annotation.LoginUsers;
 import com.seniors.common.dto.DataResponseDto;
+import com.seniors.common.dto.ErrorResponse;
 import com.seniors.config.security.CustomUserDetails;
 import com.seniors.domain.comment.dto.CommentDto;
 import com.seniors.domain.comment.entity.Comment;
@@ -34,6 +35,8 @@ public class CommentController {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentCreateDto.class)))
     @ApiResponse(responseCode = "200", description = "생성 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+    @ApiResponse(responseCode = "500", description = "생성 실패",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @PostMapping("")
     public DataResponseDto<String> commentAdd(
             @RequestBody @Valid SaveCommentDto commentDto,
@@ -48,6 +51,8 @@ public class CommentController {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentCreateDto.class)))
     @ApiResponse(responseCode = "200", description = "수정 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+    @ApiResponse(responseCode = "500", description = "수정 실패",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @PatchMapping("/{commentId}")
     public DataResponseDto<String> commentModify(
             @Parameter(description = "댓글 ID") @PathVariable(value = "commentId") Long commentId,
@@ -60,6 +65,8 @@ public class CommentController {
     @Operation(summary = "댓글 삭제")
     @ApiResponse(responseCode = "200", description = "삭제 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+    @ApiResponse(responseCode = "500", description = "삭제 실패",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @DeleteMapping("/{commentId}")
     public DataResponseDto<String> commentRemove(
             @Parameter(description = "댓글 ID") @PathVariable(value = "commentId") Long commentId,

--- a/src/main/java/com/seniors/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/seniors/domain/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.seniors.config.security.CustomUserDetails;
 import com.seniors.domain.comment.dto.CommentDto;
 import com.seniors.domain.comment.entity.Comment;
 import com.seniors.domain.comment.service.CommentService;
+import com.seniors.domain.post.dto.PostDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,6 +30,8 @@ public class CommentController {
     private final CommentService commentService;
 
     @Operation(summary = "댓글 생성")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "생성 요청 body",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentCreateDto.class)))
     @ApiResponse(responseCode = "200", description = "생성 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
     @PostMapping("")
@@ -41,6 +44,8 @@ public class CommentController {
     }
 
     @Operation(summary = "댓글 수정")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정 요청 body",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentCreateDto.class)))
     @ApiResponse(responseCode = "200", description = "수정 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
     @PatchMapping("/{commentId}")

--- a/src/main/java/com/seniors/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/seniors/domain/comment/dto/CommentDto.java
@@ -3,7 +3,9 @@ package com.seniors.domain.comment.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import com.seniors.domain.comment.entity.Comment;
+import com.seniors.domain.post.dto.PostDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -13,6 +15,24 @@ import java.time.LocalDateTime;
 @ToString
 @Getter
 public class CommentDto {
+
+	@Data
+	@Builder
+	public static class CommentCreateDto {
+
+		@Schema(description = "댓글 내용", defaultValue = "내용 1", example = "내용 1이요")
+		@NotBlank(message = "Input content!")
+		private String content;
+
+		@Schema(description = "작성자 ID")
+		@NotBlank(message = "Required userId")
+		@JsonIgnore
+		private Long userId;
+
+		public static CommentDto.CommentCreateDto of(String content, Long userId) {
+			return CommentDto.CommentCreateDto.builder().content(content).userId(userId).build();
+		}
+	}
 
 	@Data
 	public static class GetCommentRes {

--- a/src/main/java/com/seniors/domain/post/controller/PostController.java
+++ b/src/main/java/com/seniors/domain/post/controller/PostController.java
@@ -6,7 +6,7 @@ import com.seniors.common.dto.DataResponseDto;
 import com.seniors.config.security.CustomUserDetails;
 import com.seniors.domain.post.dto.PostDto.GetPostRes;
 import com.seniors.domain.post.dto.PostDto.ModifyPostReq;
-import com.seniors.domain.post.dto.PostDto.SavePostReq;
+import com.seniors.domain.post.dto.PostDto.PostCreateDto;
 import com.seniors.domain.post.dto.PostLikeDto.SetLikeDto;
 import com.seniors.domain.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,11 +30,13 @@ public class PostController {
 	private final PostService postService;
 
 	@Operation(summary = "게시글 생성")
+	@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "생성 요청 body",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostCreateDto.class)))
 	@ApiResponse(responseCode = "200", description = "생성 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
 	@PostMapping("")
 	public DataResponseDto<String> postAdd(
-			@RequestBody @Valid SavePostReq postDto,
+			@RequestBody @Valid PostCreateDto postDto,
 			@LoginUsers CustomUserDetails userDetails) {
 		postService.addPost(postDto, userDetails.getUserId());
 		return DataResponseDto.of("SUCCESS");
@@ -42,7 +44,7 @@ public class PostController {
 
 	@Operation(summary = "게시글 단건 조회")
 	@ApiResponse(responseCode = "200", description = "단건 조회 성공",
-			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetPostRes.class)))
 	@GetMapping("/{postId}")
 	public DataResponseDto<GetPostRes> postDetails(
 			@Parameter(description = "게시글 ID") @PathVariable(value = "postId") Long postId) {
@@ -53,7 +55,7 @@ public class PostController {
 	@Operation(summary = "게시글 리스트 조회")
 	@ApiResponse(responseCode = "200", description = "리스트 조회 성공",
 			content = @Content(mediaType = "application/json", schema =
-			@Schema(implementation = DataResponseDto.class)))
+			@Schema(implementation = GetPostRes.class)))
 	@GetMapping("")
 	public DataResponseDto<CustomPage<GetPostRes>> postList(
 			@RequestParam(required = false, defaultValue = "1") int page,
@@ -64,6 +66,8 @@ public class PostController {
 	}
 
 	@Operation(summary = "게시글 수정")
+	@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정 요청 body",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostCreateDto.class)))
 	@ApiResponse(responseCode = "200", description = "단건 수정 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
 	@PatchMapping("/{postId}")

--- a/src/main/java/com/seniors/domain/post/controller/PostController.java
+++ b/src/main/java/com/seniors/domain/post/controller/PostController.java
@@ -3,10 +3,12 @@ package com.seniors.domain.post.controller;
 import com.seniors.common.annotation.LoginUsers;
 import com.seniors.common.dto.CustomPage;
 import com.seniors.common.dto.DataResponseDto;
+import com.seniors.common.dto.ErrorResponse;
 import com.seniors.config.security.CustomUserDetails;
 import com.seniors.domain.post.dto.PostDto.GetPostRes;
 import com.seniors.domain.post.dto.PostDto.ModifyPostReq;
 import com.seniors.domain.post.dto.PostDto.PostCreateDto;
+import com.seniors.domain.post.dto.PostDto.SavePostReq;
 import com.seniors.domain.post.dto.PostLikeDto.SetLikeDto;
 import com.seniors.domain.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +38,7 @@ public class PostController {
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
 	@PostMapping("")
 	public DataResponseDto<String> postAdd(
-			@RequestBody @Valid PostCreateDto postDto,
+			@RequestBody @Valid SavePostReq postDto,
 			@LoginUsers CustomUserDetails userDetails) {
 		postService.addPost(postDto, userDetails.getUserId());
 		return DataResponseDto.of("SUCCESS");
@@ -55,7 +57,7 @@ public class PostController {
 	@Operation(summary = "게시글 리스트 조회")
 	@ApiResponse(responseCode = "200", description = "리스트 조회 성공",
 			content = @Content(mediaType = "application/json", schema =
-			@Schema(implementation = GetPostRes.class)))
+			@Schema(implementation = CustomPage.class)))
 	@GetMapping("")
 	public DataResponseDto<CustomPage<GetPostRes>> postList(
 			@RequestParam(required = false, defaultValue = "1") int page,
@@ -92,10 +94,12 @@ public class PostController {
 	}
 
 	@Operation(summary = "게시글 좋아요")
+	@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "좋아요 상태 값 body",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = SetLikeDto.class)))
 	@ApiResponse(responseCode = "200", description = "좋아요 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
 	@ApiResponse(responseCode = "500", description = "좋아요 실패",
-			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
 	@PostMapping("/like")
 	public DataResponseDto<String> postLike(
 			@Parameter(description = "게시글 ID") @RequestParam(name = "postId", value = "postId") Long postId,

--- a/src/main/java/com/seniors/domain/post/controller/PostController.java
+++ b/src/main/java/com/seniors/domain/post/controller/PostController.java
@@ -36,6 +36,8 @@ public class PostController {
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostCreateDto.class)))
 	@ApiResponse(responseCode = "200", description = "생성 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+	@ApiResponse(responseCode = "500", description = "생성 실패",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
 	@PostMapping("")
 	public DataResponseDto<String> postAdd(
 			@RequestBody @Valid SavePostReq postDto,
@@ -47,6 +49,8 @@ public class PostController {
 	@Operation(summary = "게시글 단건 조회")
 	@ApiResponse(responseCode = "200", description = "단건 조회 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetPostRes.class)))
+	@ApiResponse(responseCode = "500", description = "단건 조회 실패",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
 	@GetMapping("/{postId}")
 	public DataResponseDto<GetPostRes> postDetails(
 			@Parameter(description = "게시글 ID") @PathVariable(value = "postId") Long postId) {
@@ -58,6 +62,8 @@ public class PostController {
 	@ApiResponse(responseCode = "200", description = "리스트 조회 성공",
 			content = @Content(mediaType = "application/json", schema =
 			@Schema(implementation = CustomPage.class)))
+	@ApiResponse(responseCode = "500", description = "리스트 조회 실패",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
 	@GetMapping("")
 	public DataResponseDto<CustomPage<GetPostRes>> postList(
 			@RequestParam(required = false, defaultValue = "1") int page,
@@ -72,6 +78,8 @@ public class PostController {
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostCreateDto.class)))
 	@ApiResponse(responseCode = "200", description = "단건 수정 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+	@ApiResponse(responseCode = "500", description = "단건 수정 실패",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
 	@PatchMapping("/{postId}")
 	public DataResponseDto<String> postModify(
 			@Parameter(description = "게시글 ID") @PathVariable(value = "postId") Long postId,
@@ -84,6 +92,8 @@ public class PostController {
 	@Operation(summary = "게시글 단건 삭제")
 	@ApiResponse(responseCode = "200", description = "단건 삭제 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = DataResponseDto.class)))
+	@ApiResponse(responseCode = "500", description = "단건 삭제 실패",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
 	@DeleteMapping("/{postId}")
 	public DataResponseDto<String> postRemove(
 			@Parameter(description = "게시글 ID") @PathVariable(value = "postId") Long postId,

--- a/src/main/java/com/seniors/domain/post/dto/PostLikeDto.java
+++ b/src/main/java/com/seniors/domain/post/dto/PostLikeDto.java
@@ -11,7 +11,7 @@ public class PostLikeDto {
 
     @Data
     public static class SetLikeDto {
-        @Schema(description = "현재 좋아요 상태")
+        @Schema(description = "현재 좋아요 상태", defaultValue = "false")
         private Boolean status;
     }
 }

--- a/src/main/java/com/seniors/domain/post/service/PostService.java
+++ b/src/main/java/com/seniors/domain/post/service/PostService.java
@@ -4,7 +4,7 @@ import com.seniors.common.dto.CustomPage;
 import com.seniors.common.exception.type.BadRequestException;
 import com.seniors.domain.post.dto.PostDto.GetPostRes;
 import com.seniors.domain.post.dto.PostDto.ModifyPostReq;
-import com.seniors.domain.post.dto.PostDto.SavePostReq;
+import com.seniors.domain.post.dto.PostDto.PostCreateDto;
 import com.seniors.domain.post.entity.Post;
 import com.seniors.domain.post.repository.PostLikeRepository;
 import com.seniors.domain.post.repository.PostRepository;
@@ -29,7 +29,7 @@ public class PostService {
 	private final UsersRepository usersRepository;
 
 	@Transactional
-	public void addPost(SavePostReq postReq, Long userId) {
+	public void addPost(PostCreateDto postReq, Long userId) {
 		if (postReq.getTitle() == null || postReq.getTitle().isEmpty() || postReq.getContent() == null || postReq.getContent().isEmpty()) {
 			throw new BadRequestException("Title or Content is required");
 		}

--- a/src/main/java/com/seniors/domain/post/service/PostService.java
+++ b/src/main/java/com/seniors/domain/post/service/PostService.java
@@ -2,9 +2,11 @@ package com.seniors.domain.post.service;
 
 import com.seniors.common.dto.CustomPage;
 import com.seniors.common.exception.type.BadRequestException;
+import com.seniors.domain.post.dto.PostDto;
 import com.seniors.domain.post.dto.PostDto.GetPostRes;
 import com.seniors.domain.post.dto.PostDto.ModifyPostReq;
 import com.seniors.domain.post.dto.PostDto.PostCreateDto;
+import com.seniors.domain.post.dto.PostDto.SavePostReq;
 import com.seniors.domain.post.entity.Post;
 import com.seniors.domain.post.repository.PostLikeRepository;
 import com.seniors.domain.post.repository.PostRepository;
@@ -29,7 +31,7 @@ public class PostService {
 	private final UsersRepository usersRepository;
 
 	@Transactional
-	public void addPost(PostCreateDto postReq, Long userId) {
+	public void addPost(SavePostReq postReq, Long userId) {
 		if (postReq.getTitle() == null || postReq.getTitle().isEmpty() || postReq.getContent() == null || postReq.getContent().isEmpty()) {
 			throw new BadRequestException("Title or Content is required");
 		}

--- a/src/main/java/com/seniors/domain/users/controller/UsersController.java
+++ b/src/main/java/com/seniors/domain/users/controller/UsersController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "사용자", description = "사용자 API 명세서")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -32,7 +34,7 @@ public class UsersController {
 	 * @param userDetails
 	 * @return ResponseEntity
 	 */
-	@Operation(summary = "유저 검증")
+	@Operation(summary = "사용자 검증")
 	@ApiResponse(responseCode = "200", description = "검증 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseEntity.class)))
 	@ApiResponse(responseCode = "401", description = "검증 실패",


### PR DESCRIPTION
## 📕 제목
Swagger Response DTO 수정

## 📗 작업 내용
Swagger Req, Res DTO 적합하게 수정 및 Authorization
> 구현 내용 및 작업 했던 내역

- [x] Swagger Config에 Authorization 추가
- [x] Response, Request Swagger 정의
- [ ] Auth, Users Swagger 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 카카오 Oauth Server에서 받은 code로 accessToken을 발급받아 해당 토큰을 Swagger 페이지에 Authorization 영역에 토큰 추가하고 로그인 시도하면 userDetails에 자동으로 userId가 주입되어 다른 API 테스트도 가능
- Controller 코드에서 Request 영역 및 추가적으로 500에러 ApiResponse 추가
